### PR TITLE
Light mode button transition animation is fixed, no longer cropped

### DIFF
--- a/frontend/src/components/DarkLightModeButton.vue
+++ b/frontend/src/components/DarkLightModeButton.vue
@@ -3,7 +3,7 @@
         <template #activator="{on}">
             <v-btn
                 class="mr-2 button"
-                small fab tile elevation="0"
+                small fab elevation="0"
                 v-on="on"
                 @click="darkMode"
             >
@@ -13,12 +13,12 @@
             </v-btn>
         </template>
         <span>Switch to Light Mode</span>
-    </v-tooltip>
+    </v-tooltip> 
     <v-tooltip v-else bottom>
         <template #activator="{on}">
             <v-btn
                 class="mr-2 button"
-                small fab tile elevation="0"
+                small fab elevation="0"
                 v-on="on"
                 @click="darkMode"
             >
@@ -51,7 +51,7 @@ export default {
 }
 
 .button {
-    opacity: 0.8;
+    opacity: 0.7;
 }
 
 .button:hover {

--- a/frontend/src/pages/Pathway/PathwaysPage.vue
+++ b/frontend/src/pages/Pathway/PathwaysPage.vue
@@ -31,7 +31,6 @@
 <script>
 import PathwayCategory from '../../components/PathwayCategory'
 import Breadcrumbs from '../../components/Breadcrumbs'
-
 import { pathwayCategories } from '../../data/data.js'
 import breadcrumbs from '../../data/breadcrumbs.js'
 


### PR DESCRIPTION
I removed the tile aspect to make it just a circle, so the fade in transition isn't cut off.