### PR TITLE
Moved the alert out of the way

### DIFF
--- a/frontend/src/components/CourseTableCourse.vue
+++ b/frontend/src/components/CourseTableCourse.vue
@@ -6,8 +6,7 @@
             transition="scale-transition"
             @click="toggleCheckbox()"
         >
-            This course has pre-requisite(s).
-            <br>
+            This course has pre-requisite(s): 
             <span v-for='(prereq, index) in course.prerequisites' :key="prereq">
                 {{prereq}} <span v-if="index < course.prerequisites.length-1">,&nbsp;</span>
             </span>
@@ -219,12 +218,15 @@ export default {
 <style scoped lang="scss">
 
 .v-alert {
-    // width: 98.6%;
-    width:fit-content;
-    align-self: center;
     position: absolute;
     z-index: 100;
     cursor: pointer;
+    margin-left: 40%; 
+    padding: 5px; 
+    padding-right: 10px;
+    margin-top: 10px;
+    display: inline;
+    max-width: 50%;
 }
 .maxHeight {
     height: 100%;


### PR DESCRIPTION
Closes #141
i just moved the alert out of the way for now.
I think a better way to notify the user that the course has prereqs tho is below:
![image](https://user-images.githubusercontent.com/82001942/182452548-243b857b-3112-4da4-be5e-572664e208c3.png)
where when you click the checkbox, "PR" expands to "Pre-Requisites: blah blah blah". OR even just show the prerequisites without even clicking the checkbox first. Might do that one or the other on thursday 