### PR TITLE
Header fixes

### DIFF
--- a/frontend/src/components/DarkLightModeButton.vue
+++ b/frontend/src/components/DarkLightModeButton.vue
@@ -8,7 +8,6 @@
                 size="small"
                 color="yellow darken-2"
                 :prepend-icon="correctIcon"
-                style="padding-top:21px;"
                 v-on="off"
                 @click="darkMode"
             />

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -19,7 +19,7 @@
             </v-layout>
         </v-container>
     </v-app-bar>
-</template>       
+</template>
 
 <script>
 import DarkLightModeButton from './DarkLightModeButton.vue'
@@ -29,7 +29,7 @@ import YearSelection from '../components/YearSelection.vue'
 export default {
     name: 'Header',
     components: {
-        DarkLightModeButton, 
+        DarkLightModeButton,
         HeaderNav,
         YearSelection
     }
@@ -39,6 +39,12 @@ export default {
 <style scoped>
 .navbar {
     border-bottom: 3px solid var(--v-primary-base) !important;
+}
+
+/deep/ .v-input__control {
+    display: flex;
+    flex-direction: inherit !important;
+    flex-wrap: inherit !important;
 }
 
 /* Remove navbar padding */

--- a/frontend/src/components/HeaderNav.vue
+++ b/frontend/src/components/HeaderNav.vue
@@ -33,7 +33,7 @@ export default {
 }
 
 .button {
-    opacity: 1;
+    opacity: 0.8;
     margin-right: 0.5em;
 }
 

--- a/frontend/src/components/YearSelection.vue
+++ b/frontend/src/components/YearSelection.vue
@@ -22,6 +22,13 @@ export default {
             selection: this.$store.state.year
         }
     },
+    created() {
+        let choice = this.$store.state.year;
+        if (choice === "") {
+            this.$store.commit('changeYear', years[0]);
+        }
+        this.selection = this.$store.state.year;
+    },
     computed: {
         allyears() {
             return years;

--- a/frontend/src/store/store.js
+++ b/frontend/src/store/store.js
@@ -29,7 +29,7 @@ export default new Vuex.Store({
         // List of pathways that have been bookmarked
         bookmarkedPathways: {},
         // The calendar year to display the information about
-        year: "2021-2022"
+        year: ""
 
     },
     plugins: [createPersistedState()],


### PR DESCRIPTION
Fixes to a couple of problems that were bugging me about the header. First, the initial year selection (if the user has not chosen anything) was hardcoded to 2021-2022; that is now chosen to be the current year/last one we have records for (assuming years.json is kept in reverse chronological order). Second, I made the year selection and dark/light mode button vertically centered within the header (ish; the switch is slightly off center for reasons I have not figured out yet), which looks nicer. Finally, the "My Pathways" button on the top right now becomes lighter when you hover over it, like the rest of the buttons on the home page.