### PR TITLE
Fix Catalog Redirection

### DIFF
--- a/frontend/src/components/YearSelection.vue
+++ b/frontend/src/components/YearSelection.vue
@@ -37,7 +37,9 @@ export default {
     methods: {
         updateYear() {
             this.$store.commit('changeYear', this.selection);
-            location.reload();
+            if(this.$route.path !== "/pathways")  this.$router.push("/pathways");
+            else location.reload();
+
         }
     }
 }


### PR DESCRIPTION
Closes #220

Changing the catalog while looking at a pathway would sometimes result in a 404 page not found. This change makes it so when you are changing the catalog year it will redirect you to select a pathway.