### PR TITLE
Added Quatalog Link

### DIFF
--- a/frontend/src/pages/Courses/CoursePage.vue
+++ b/frontend/src/pages/Courses/CoursePage.vue
@@ -13,6 +13,11 @@
                 <a :href="`/pathway?pathway=${encodeURIComponent(item.name)}`" @click.stop>  {{ item.name }}</a>
             </li>
         </ul>
+      <div class="header">
+        <h2>Quatalog:</h2>
+        <a :href="`https://quatalog.com/courses/${course.subj}-${course.ID}`">This Courses Quatalog Entry (Contains more detailed course information)</a>
+      </div>
+
         <br>
         <template v-if="course.professors.length !== 0">
             <h2>Professors:</h2>


### PR DESCRIPTION
Works on #223 

Added a Quatalog link to the course description page. Offers a link to Quatalog which offers more in detail information about a specific course than our current course page offers.